### PR TITLE
Deactivated check for 1D free_dims in evaluate()

### DIFF
--- a/pgdrome/model.py
+++ b/pgdrome/model.py
@@ -757,15 +757,15 @@ class PGD:
                 coord,
             )
 
-        # only possible if freeDims are one dimensional
-        for i in range(len(free_dim)):
-            if (
-                sum(self.mesh[free_dim[i]].dataY) != 0
-                and sum(self.mesh[free_dim[i]].dataZ) != 0
-            ):
-                raise ValueError(
-                    "free Dimensions are not 1D, interpolation not possible"
-                )
+        # # only possible if free_dims are one dimensional
+        # for i in range(len(free_dim)):
+        #     if (
+        #         sum(self.mesh[free_dim[i]].dataY) != 0
+        #         and sum(self.mesh[free_dim[i]].dataZ) != 0
+        #     ):
+        #         raise ValueError(
+        #             "free Dimensions are not 1D, interpolation not possible"
+        #         )
 
         # check if attri is possible
         if attri >= len(self.mesh[fixed_dim].attributes):


### PR DESCRIPTION
The deactivated check is no longer needed, since a multi-dimensional handling via tensors is implemented.